### PR TITLE
Add maintenance reason

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -144,6 +144,7 @@ Util.getNodeInfo = function (node, region, alerts_url) {
     target_power_state: node.target_power_state,
     last_error: node.last_error || '',
     maintenance: node.maintenance,
+    maintenance_reason: node.maintenance_reason || '',
     error: (node.last_error !== null),
     flavor: Util.getNodeFlavor(node),
     agent_url: node[driver_info_key].agent_url,

--- a/routes/detail.js
+++ b/routes/detail.js
@@ -68,6 +68,9 @@ var getNodeDetail = function (res, node, region) {
       last_heartbeat: time_since_heartbeat + 's ago',
       console_enabled: node.console_enabled
     },
+    maintenance: {
+      maintenance_reason: node.maintenance_reason
+    },
     ipmi: {
       ipmi_address: node.driver_info.ipmi_address,
       ipmi_username: node.driver_info.ipmi_username,

--- a/routes/summary.js
+++ b/routes/summary.js
@@ -138,7 +138,8 @@ var SummaryRouter = function (io) {
           flavor: node.flavor,
           power_state: node.power_state,
           provision_state: node.provision_state,
-          error: node.last_error
+          error: node.last_error,
+          maintenance_reason: node.maintenance_reason
         };
 
         // setting the html char code `&nbsp;` will fix datatables being

--- a/views/detail.jade
+++ b/views/detail.jade
@@ -106,6 +106,19 @@ block content
     .panel.panel-default
       .panel-heading
         h1.panel-title
+          a(data-toggle="collapse" data-parents="#accordion" href="#maintenance") Maintenance Info
+      #maintenance.panel-collapse.collapse
+        .panel-body
+          div
+            table.table.table-hover
+              tbody
+                tr
+                  td Maintenance Reason
+                  td=maintenance.maintenance_reason
+
+    .panel.panel-default
+      .panel-heading
+        h1.panel-title
           a(data-toggle="collapse" data-parents="#accordion" href="#ipmi") IPMI
       #ipmi.panel-collapse.collapse
         .panel-body

--- a/views/tables.jade
+++ b/views/tables.jade
@@ -248,7 +248,8 @@ block content
           'Flavor': { data: 'flavor' },
           'Power State': { data: 'power_state' },
           'Provision State': { data: 'provision_state' },
-          'Error': { data: 'error' }
+          'Error': { data: 'error' },
+          'Maintenance Reason': { data: 'maintenance_reason' }
         },
         el: '#maintenance-table',
         panel: $('#maintenance-panel'),


### PR DESCRIPTION
This change add:
- The maintenance reason to the Maintenance Nodes table in summary page
- Maintenance Info section to detail page.
